### PR TITLE
Add --enable-cleartext-plugin option

### DIFF
--- a/src/harlequin_mysql/adapter.py
+++ b/src/harlequin_mysql/adapter.py
@@ -380,6 +380,7 @@ class HarlequinMySQLAdapter(HarlequinAdapter):
         ssl_key: str | None = None,
         openid_token_file: str | None = None,
         pool_size: str | int | None = 5,
+        enable_cleartext_plugin: str | bool | None = False,
         **_: Any,
     ) -> None:
         if conn_str:
@@ -405,6 +406,7 @@ class HarlequinMySQLAdapter(HarlequinAdapter):
                 "ssl_key": ssl_key,
                 "openid_token_file": openid_token_file,
                 "pool_size": int(pool_size) if pool_size is not None else 5,
+                "allow_local_infile": enable_cleartext_plugin if enable_cleartext_plugin is not None else False,
             }
         except (ValueError, TypeError) as e:
             raise HarlequinConfigError(

--- a/src/harlequin_mysql/adapter.py
+++ b/src/harlequin_mysql/adapter.py
@@ -406,7 +406,9 @@ class HarlequinMySQLAdapter(HarlequinAdapter):
                 "ssl_key": ssl_key,
                 "openid_token_file": openid_token_file,
                 "pool_size": int(pool_size) if pool_size is not None else 5,
-                "allow_local_infile": enable_cleartext_plugin if enable_cleartext_plugin is not None else False,
+                "allow_local_infile": enable_cleartext_plugin
+                if enable_cleartext_plugin is not None
+                else False,
             }
         except (ValueError, TypeError) as e:
             raise HarlequinConfigError(

--- a/src/harlequin_mysql/cli_options.py
+++ b/src/harlequin_mysql/cli_options.py
@@ -132,6 +132,12 @@ pool_size = TextOption(
 )
 
 
+enable_cleartext_plugin = FlagOption(
+    name="enable-cleartext-plugin",
+    description="Enable the cleartext authentication plugin for MySQL connections.",
+)
+
+
 MYSQLADAPTER_OPTIONS = [
     host,
     port,
@@ -148,4 +154,5 @@ MYSQLADAPTER_OPTIONS = [
     ssl_key,
     openid_token_file,
     pool_size,
+    enable_cleartext_plugin,
 ]

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -69,7 +69,10 @@ def test_enable_cleartext_plugin_false() -> None:
 
 def test_enable_cleartext_plugin_string_true() -> None:
     adapter = HarlequinMySQLAdapter(
-        conn_str=tuple(), user="root", password="example", enable_cleartext_plugin="true"
+        conn_str=tuple(),
+        user="root",
+        password="example",
+        enable_cleartext_plugin="true",
     )
     assert adapter.options["allow_local_infile"] == "true"
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -48,6 +48,32 @@ def test_init_extra_kwargs() -> None:
     ).connect()
 
 
+def test_enable_cleartext_plugin_default() -> None:
+    adapter = HarlequinMySQLAdapter(conn_str=tuple(), user="root", password="example")
+    assert adapter.options["allow_local_infile"] is False
+
+
+def test_enable_cleartext_plugin_true() -> None:
+    adapter = HarlequinMySQLAdapter(
+        conn_str=tuple(), user="root", password="example", enable_cleartext_plugin=True
+    )
+    assert adapter.options["allow_local_infile"] is True
+
+
+def test_enable_cleartext_plugin_false() -> None:
+    adapter = HarlequinMySQLAdapter(
+        conn_str=tuple(), user="root", password="example", enable_cleartext_plugin=False
+    )
+    assert adapter.options["allow_local_infile"] is False
+
+
+def test_enable_cleartext_plugin_string_true() -> None:
+    adapter = HarlequinMySQLAdapter(
+        conn_str=tuple(), user="root", password="example", enable_cleartext_plugin="true"
+    )
+    assert adapter.options["allow_local_infile"] == "true"
+
+
 def test_connect_raises_connection_error() -> None:
     with pytest.raises(HarlequinConnectionError):
         _ = HarlequinMySQLAdapter(conn_str=("foo",)).connect()


### PR DESCRIPTION
This changeset adds the `--enable-cleartext-plugin` param to allow passing in cleartext passwords.

This is passed to the adapter's `allow_local_infile` field.

A workaround, without this configuration param, is setting the envvar `LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN`. However, the plugin config param is preferable because it allows configuration on a per-connection basis.