### PR TITLE
fix: crash after USE <database>; in a script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixes a crash after executing a `USE <database>;` statement, caused by the trailing semicolon (or backticks) being parsed as part of the database name ([tconbeer/harlequin#982](https://github.com/tconbeer/harlequin/issues/982)).
+- Failures to get a connection from the pool are now raised as query errors, so Harlequin displays them instead of crashing.
+
 ## [1.3.0] - 2025-10-29
 
 - Drops support for Python 3.9; adds support for Python 3.14

--- a/src/harlequin_mysql/adapter.py
+++ b/src/harlequin_mysql/adapter.py
@@ -18,6 +18,7 @@ from harlequin.exception import (
 )
 from mysql.connector import FieldType
 from mysql.connector.cursor import MySQLCursor
+from mysql.connector.errors import Error as MySQLError
 from mysql.connector.errors import InternalError, PoolError
 from mysql.connector.pooling import (
     MySQLConnectionPool,
@@ -29,9 +30,7 @@ from harlequin_mysql.catalog import DatabaseCatalogItem
 from harlequin_mysql.cli_options import MYSQLADAPTER_OPTIONS
 from harlequin_mysql.completions import load_completions
 
-USE_DATABASE_PROG = re.compile(
-    r"\s*use\s+([^\\/?%*:|\"<>.]{1,64})", flags=re.IGNORECASE
-)
+USE_DATABASE_PROG = re.compile(r"\s*use\s+\S", flags=re.IGNORECASE)
 QUERY_INTERRUPT_MSG = "1317 (70100): Query execution was interrupted"
 
 
@@ -158,6 +157,15 @@ class HarlequinMySQLConnection(HarlequinConnection):
             # way to show an error to the user without aborting processing
             # all the other cursors).
             return None, None
+        except MySQLError as e:
+            # the pool reconfigures and reconnects its connections lazily, so
+            # a bad config (e.g., a database that has since been dropped) shows
+            # up here. Raise a query error so Harlequin shows the message
+            # instead of crashing.
+            raise HarlequinQueryError(
+                msg=str(e),
+                title="Harlequin could not connect to your database.",
+            ) from e
 
         try:
             cur: MySQLCursor = conn.cursor(buffered=buffered)
@@ -205,24 +213,37 @@ class HarlequinMySQLConnection(HarlequinConnection):
                 retval = HarlequinMySQLCursor(cur, conn=conn, harlequin_conn=self)
             else:
                 cur.close()
+                if USE_DATABASE_PROG.match(query):
+                    self._sync_pool_database(conn)
                 conn.close()
                 if connection_id:
                     self._in_use_connections.discard(connection_id)
 
-        # this is a hack to update all connections in the pool if the user
-        # changes the database for the active connection.
-        # it is impossible to check the database or other config
-        # of a connection with an open cursor, and we can't use a dedicated
-        # connection for user queries, since mysql only supports a single
-        # (unfetched) cursor per connection.
-        if match := USE_DATABASE_PROG.match(query):
-            new_db = match.group(1)
-            self.set_pool_config(database=new_db)
         return retval
+
+    def _sync_pool_database(self, conn: PooledMySQLConnection) -> None:
+        """
+        This is a hack to update all connections in the pool if the user
+        changes the database for the active connection.
+        It is impossible to check the database or other config
+        of a connection with an open cursor, and we can't use a dedicated
+        connection for user queries, since mysql only supports a single
+        (unfetched) cursor per connection.
+
+        The active database is read back from the server, since parsing it out
+        of the query is error-prone (the query may end with a semicolon, the
+        name may be quoted, etc.).
+        """
+        with suppress(MySQLError):
+            if new_db := conn.database:
+                self.set_pool_config(database=new_db)
 
     def cancel(self) -> None:
         # get a new cursor to execute the KILL statements
-        conn, cur = self.safe_get_mysql_cursor()
+        try:
+            conn, cur = self.safe_get_mysql_cursor()
+        except HarlequinQueryError:
+            return None
         if conn is None or cur is None:
             return None
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -209,7 +209,19 @@ def test_execute_more_than_pool_size_ddl_does_not_raise(
     assert len(cursors) == number_of_ddl_queries
 
 
-def test_use_database_updates_pool(connection: HarlequinMySQLConnection) -> None:
+@pytest.mark.parametrize(
+    "query",
+    [
+        "use mysql",
+        "use mysql;",
+        "USE mysql;\n\n",
+        "use `mysql`;",
+        "  use\n  mysql  ;  ",
+    ],
+)
+def test_use_database_updates_pool(
+    connection: HarlequinMySQLConnection, query: str
+) -> None:
     conn, cur = connection.safe_get_mysql_cursor()
     assert conn is not None
     assert cur is not None
@@ -217,7 +229,7 @@ def test_use_database_updates_pool(connection: HarlequinMySQLConnection) -> None
     cur.close()
     conn.close()
 
-    connection.execute("use mysql")
+    connection.execute(query)
 
     pool_size = connection._pool.pool_size
 
@@ -236,6 +248,23 @@ def test_use_database_updates_pool(connection: HarlequinMySQLConnection) -> None
         cur.close()
     for conn in conns:
         conn.close()
+
+
+def test_use_database_script(connection: HarlequinMySQLConnection) -> None:
+    """
+    A script that starts with a USE statement should execute against the
+    named database. See harlequin#982.
+    """
+    for query in [
+        "use test;",
+        "create table temp1 (\n    id int\n);",
+        "insert into temp1 values (1);",
+    ]:
+        assert connection.execute(query) is None
+
+    cur = connection.execute("select id from test.temp1")
+    assert cur is not None
+    assert cur.fetchall() == [(1,)]
 
 
 def test_close(connection: HarlequinMySQLConnection) -> None:


### PR DESCRIPTION
Fixes [tconbeer/harlequin#982](https://github.com/tconbeer/harlequin/issues/982).

## Root cause

`USE_DATABASE_PROG` captured the database name out of the query text with a character class that didn't exclude `;`, whitespace, or backticks:

```
'use ht;'   -> 'ht;'
'use `ht`;' -> '`ht`;'
```

Harlequin hands each statement of a script to the adapter with its trailing semicolon, so running a script that starts with `USE ht;` set the pool config to `database='ht;'`. The pool applies config lazily, so the *next* `get_connection()` reconfigured and reconnected, raising `ProgrammingError: 1049 (42000): Unknown database 'ht;'`. `safe_get_mysql_cursor()` only caught `InternalError`/`PoolError`, so that escaped `execute()`, and Harlequin's query worker (`exit_on_error=True`, catches only `HarlequinQueryError`) took the app down.

## Fix

1. Stop parsing the name out of the SQL. The regex is now only a trigger; the new `_sync_pool_database()` reads the active database back from the server (`conn.database` → `SELECT DATABASE()`) on the same pooled connection before it goes back to the pool. That's authoritative, so semicolons, quoting, and escapes can't corrupt the pool config.
2. Defense in depth: `safe_get_mysql_cursor()` converts any other `mysql.connector.Error` from `get_connection()` into a `HarlequinQueryError`, so a stale pool config (e.g. the database was dropped out from under it) shows an error modal rather than terminating Harlequin. `cancel()` swallows that error, since its worker also exits on error.

## Tests

- `test_use_database_updates_pool` is parametrized over `use mysql`, `use mysql;`, `USE mysql;\n\n`, ``use `mysql`;``, and irregular whitespace.
- `test_use_database_script` replays the issue's exact script (`use test;` → `create table temp1 (...);` → `insert into temp1 values (1);`) and asserts the row lands in `test.temp1`.

Verified these catch the bug: with the source fix stashed, 5 of the 6 fail with `Unknown database 'test;'` — the reported error. With the fix, `make check` is clean (ruff, mypy, 33 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)